### PR TITLE
Fix link to auth example

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -15,7 +15,7 @@ The following sections show 3 common ways of using the JavaScript client library
 
 ### Option 1: Load the API discovery document, then assemble the request.
 
-The following example assumes the user has already signed in. For a full example of how to sign in a user, see the [full auth sample](https://developers.google.com/api-client-library/javascript/samples/samples#authorizing-and-making-authorized-requests).
+The following example assumes the user has already signed in. For a full example of how to sign in a user, see the [full auth sample](https://github.com/google/google-api-javascript-client/blob/master/docs/samples.md#authorizing-and-making-authorized-requests).
 
 ```html
 <script src="https://apis.google.com/js/api.js"></script>


### PR DESCRIPTION
Seems that the link forwarding is going to the wrong place. Fixed that.