### PR TITLE
fixed broken link for CORS support

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -78,7 +78,7 @@ gapi.load('client', start);
 
 ### Option 3: Use CORS
 
-Google APIs support [CORS](http://www.w3.org/TR/cors/). If your application needs to do media uploads and downloads, it should use CORS. See the [CORS Support](https://developers.google.com/api-client-library/javascript/features/cors) page for details.
+Google APIs support [CORS](http://www.w3.org/TR/cors/). If your application needs to do media uploads and downloads, it should use CORS. See the [CORS Support](https://github.com/google/google-api-javascript-client/blob/master/docs/cors.md) page for details.
 
 [](#top_of_page)Supported environments
 --------------------------------------


### PR DESCRIPTION
developers.google.com redirects to the github repo. I changed the link to the specific location in the github repo