### PR TITLE
Fix broken link to 'Using Promises' documentation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -669,7 +669,7 @@ alert('gapi.client could not load in a timely manner!');
   </h4>
   <p>
     For more information about using promises, see
-    <a href="/api-client-library/javascript/features/promises">Using Promises</a>.
+    <a href="/docs/promises.md">Using Promises</a>.
   </p>
 </section>
 <section id="gapiclientRequestexecute">


### PR DESCRIPTION
Link in reference.md out of date.