### PR TITLE
Add clarification for Chrome Extensions Manifest v3

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,3 +29,8 @@ The JavaScript client library does not directly support logging the user out of 
 Since logging out of the application also logs the user out of the Google account, it is not recommended to log the user out unless the user requests this explicitly.
 
 For a workaround that allows your application to log the user out programatically, see [this topic](https://groups.google.com/forum/?fromgroups=#!topic/google-api-javascript-client/PCs8xXV4wxk) in the JavaScript client library discussion group.
+
+
+### Is it possible to use the JavaScript client library in a Chrome Extension?
+
+Chrome Extensions using Manifest v3 do not allow [remotely hosted code](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#remotely-hosted-code), so the Javascript client library cannot be used in this case.

--- a/docs/start.md
+++ b/docs/start.md
@@ -85,6 +85,8 @@ Google APIs support [CORS](http://www.w3.org/TR/cors/). If your application need
 
 The JavaScript client library works with the same browsers supported by [Google Apps](https://support.google.com/a/answer/33864) except that mobile browsers are currently not fully supported. It only works within HTML documents with a `<body>` element served using the `https` _(preferred)_ and `http` protocols. However, `<iframe sandbox>` elements and other restricted execution contexts are not supported.
 
+Use of this JavaScript client library is not supported in Chrome Browser extensions using Manifest v3 due to the [No remotely hosted code](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#remotely-hosted-code) requirement.
+
 [](#top_of_page)Setup
 ---------------------
 


### PR DESCRIPTION
GAPI is not supported for Chrome Extensions with Manifest v3 due to the no remotely hosted code requirement.

Updated docs to reflect this